### PR TITLE
add link definition for memoization

### DIFF
--- a/lib/universe.coffee
+++ b/lib/universe.coffee
@@ -91,6 +91,7 @@ _.defaults exports, {Cell, Square}
 # [rules]: http:rules.html
 # [gc]: http:gc.html
 # [universe]: http:universe.html
+# [memoization]: http:memoization.html
 
 # ---
 #


### PR DESCRIPTION
- without link def, raw markdown was displayed instead of a link
